### PR TITLE
Update tests for xUnit v3 and consistent cancellation tokens

### DIFF
--- a/Test/AutoTest.Integration.Test/AutoTest.Integration.Test.csproj
+++ b/Test/AutoTest.Integration.Test/AutoTest.Integration.Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,10 +11,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Test/AutoTest.Integration.Test/AutoTest.Integration.Test.csproj
+++ b/Test/AutoTest.Integration.Test/AutoTest.Integration.Test.csproj
@@ -14,10 +14,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Test/AutoTest.Integration.Test/Controllers/AccessControllerShould.cs
+++ b/Test/AutoTest.Integration.Test/Controllers/AccessControllerShould.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoTest.Integration.Test.Fixtures;
 using AutoTest.Integration.Test.Tooling;
@@ -23,7 +24,7 @@ public class AccessControllerShould : IClassFixture<CustomWebApplicationFactory<
     [Fact]
     public async Task GetUnauthorised()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/access/");
+        var res = await unAuthorisedClient.GetAsync("/api/access/", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var accessModel = await res.DeserialiseAsync<AccessModel>();
         accessModel.Should().NotBeNull();
@@ -33,7 +34,7 @@ public class AccessControllerShould : IClassFixture<CustomWebApplicationFactory<
     [Fact]
     public async Task GetAuthorised()
     {
-        var res = await authorisedClient.GetAsync("/api/access/");
+        var res = await authorisedClient.GetAsync("/api/access/", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var accessModel = await res.DeserialiseAsync<AccessModel>();
         accessModel.Should().NotBeNull();

--- a/Test/AutoTest.Integration.Test/Controllers/ClubsControllerShould.cs
+++ b/Test/AutoTest.Integration.Test/Controllers/ClubsControllerShould.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoTest.Domain.StorageModels;
 using AutoTest.Integration.Test.Fixtures;
@@ -22,7 +23,7 @@ public class ClubsControllerShould : IClassFixture<CustomWebApplicationFactory<S
     [Fact]
     public async Task GetResults()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/clubs/");
+        var res = await unAuthorisedClient.GetAsync("/api/clubs/", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<IEnumerable<Club>>();
         content.Should().NotBeEmpty();

--- a/Test/AutoTest.Integration.Test/Controllers/EntrantsControllerShould.cs
+++ b/Test/AutoTest.Integration.Test/Controllers/EntrantsControllerShould.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoTest.Domain.StorageModels;
 using AutoTest.Integration.Test.Fixtures;
@@ -19,7 +20,7 @@ public class EntrantsControllerShould(CustomWebApplicationFactory<Startup> fixtu
     [Fact]
     public async Task GetResults()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/entrants/22");
+        var res = await unAuthorisedClient.GetAsync("/api/entrants/22", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<IEnumerable<PublicEntrantModel>>();
         content.Should().NotBeEmpty();
@@ -28,7 +29,7 @@ public class EntrantsControllerShould(CustomWebApplicationFactory<Startup> fixtu
     [Fact]
     public async Task GetSingle()
     {
-        var res = await authorisedClient.GetAsync("/api/entrants/22/1");
+        var res = await authorisedClient.GetAsync("/api/entrants/22/1", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<Entrant>();
         content.Should().NotBeNull();
@@ -37,7 +38,7 @@ public class EntrantsControllerShould(CustomWebApplicationFactory<Startup> fixtu
     [Fact]
     public async Task NotFound()
     {
-        var res = await authorisedClient.GetAsync("/api/entrants/22/9999");
+        var res = await authorisedClient.GetAsync("/api/entrants/22/9999", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
     }
 }

--- a/Test/AutoTest.Integration.Test/Controllers/EventsControllerShould.cs
+++ b/Test/AutoTest.Integration.Test/Controllers/EventsControllerShould.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoTest.Domain.StorageModels;
 using AutoTest.Integration.Test.Fixtures;
@@ -27,7 +28,7 @@ public class EventsControllerShould : IClassFixture<CustomWebApplicationFactory<
     [Fact]
     public async Task GetAll()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/events/");
+        var res = await unAuthorisedClient.GetAsync("/api/events/", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<IEnumerable<Event>>();
         content.Should().NotBeEmpty();
@@ -36,7 +37,7 @@ public class EventsControllerShould : IClassFixture<CustomWebApplicationFactory<
     [Fact]
     public async Task AddFailValidation()
     {
-        var res = await authorisedClient.PutAsync("/api/events/22", JsonContent.Create(new EventSaveModel() { ClubId = 1 }));
+        var res = await authorisedClient.PutAsync("/api/events/22", JsonContent.Create(new EventSaveModel() { ClubId = 1 }), CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
         var content = await res.DeserialiseAsync<ProblemDetails>();
         content.Should().NotBeNull();
@@ -45,18 +46,18 @@ public class EventsControllerShould : IClassFixture<CustomWebApplicationFactory<
     [Fact]
     public async Task GetMaps()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/events/1/maps");
+        var res = await unAuthorisedClient.GetAsync("/api/events/1/maps", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
-        var content = await res.Content.ReadAsStringAsync();
+        var content = await res.Content.ReadAsStringAsync(CancellationToken.None);
         content.Should().NotBeNull();
     }
 
     [Fact]
     public async Task GetRegulations()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/events/1/regulations");
+        var res = await unAuthorisedClient.GetAsync("/api/events/1/regulations", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
-        var content = await res.Content.ReadAsStringAsync();
+        var content = await res.Content.ReadAsStringAsync(CancellationToken.None);
         content.Should().NotBeNull();
     }
 }

--- a/Test/AutoTest.Integration.Test/Controllers/MarshalsControllerShould.cs
+++ b/Test/AutoTest.Integration.Test/Controllers/MarshalsControllerShould.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoTest.Domain.StorageModels;
 using AutoTest.Integration.Test.Fixtures;
@@ -19,7 +20,7 @@ public class MarshalsControllerShould(CustomWebApplicationFactory<Startup> fixtu
     [Fact]
     public async Task GetResults()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/marshals/22");
+        var res = await unAuthorisedClient.GetAsync("/api/marshals/22", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<IEnumerable<PublicMarshalModel>>();
         content.Should().NotBeEmpty();
@@ -28,7 +29,7 @@ public class MarshalsControllerShould(CustomWebApplicationFactory<Startup> fixtu
     [Fact]
     public async Task GetSingle()
     {
-        var res = await authorisedClient.GetAsync("/api/marshals/22/1");
+        var res = await authorisedClient.GetAsync("/api/marshals/22/1", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<Marshal>();
         content.Should().NotBeNull();
@@ -37,7 +38,7 @@ public class MarshalsControllerShould(CustomWebApplicationFactory<Startup> fixtu
     [Fact]
     public async Task NotFound()
     {
-        var res = await authorisedClient.GetAsync("/api/marshals/22/9999");
+        var res = await authorisedClient.GetAsync("/api/marshals/22/9999", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.NotFound);
     }
 }

--- a/Test/AutoTest.Integration.Test/Controllers/NotificationsControllerShould.cs
+++ b/Test/AutoTest.Integration.Test/Controllers/NotificationsControllerShould.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoTest.Domain.StorageModels;
 using AutoTest.Integration.Test.Fixtures;
@@ -22,7 +23,7 @@ public class NotificationsControllerShould : IClassFixture<CustomWebApplicationF
     [Fact]
     public async Task GetResults()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/notifications/22");
+        var res = await unAuthorisedClient.GetAsync("/api/notifications/22", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<IEnumerable<Notification>>();
         content.Should().NotBeEmpty();

--- a/Test/AutoTest.Integration.Test/Controllers/ProfileControllerShould.cs
+++ b/Test/AutoTest.Integration.Test/Controllers/ProfileControllerShould.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoTest.Domain.StorageModels;
 using AutoTest.Integration.Test.Fixtures;
@@ -23,14 +24,14 @@ public class ProfileControllerShould : IClassFixture<CustomWebApplicationFactory
     [Fact]
     public async Task GetProfileUnauthorized()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/profile");
+        var res = await unAuthorisedClient.GetAsync("/api/profile", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.Unauthorized);
     }
 
     [Fact]
     public async Task GetProfile()
     {
-        var res = await authorisedClient.GetAsync("/api/profile");
+        var res = await authorisedClient.GetAsync("/api/profile", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<Profile>();
         content.Should().BeEquivalentTo(new Profile("user@test.com", "", "", Domain.Enums.Age.Senior, false));

--- a/Test/AutoTest.Integration.Test/Controllers/ResultsControllerShould.cs
+++ b/Test/AutoTest.Integration.Test/Controllers/ResultsControllerShould.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoTest.Integration.Test.Fixtures;
 using AutoTest.Integration.Test.Tooling;
@@ -22,7 +23,7 @@ public class ResultsControllerShould : IClassFixture<CustomWebApplicationFactory
     [Fact]
     public async Task GetResults()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/results/22");
+        var res = await unAuthorisedClient.GetAsync("/api/results/22", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<IEnumerable<Result>>();
         content.Should().NotBeEmpty();
@@ -31,7 +32,7 @@ public class ResultsControllerShould : IClassFixture<CustomWebApplicationFactory
     [Fact]
     public async Task GetAwards()
     {
-        var res = await unAuthorisedClient.GetAsync("/api/results/22/awards");
+        var res = await unAuthorisedClient.GetAsync("/api/results/22/awards", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<Awards>();
         content.Should().NotBeNull();

--- a/Test/AutoTest.Integration.Test/Controllers/TestRunsControllerShould.cs
+++ b/Test/AutoTest.Integration.Test/Controllers/TestRunsControllerShould.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoTest.Domain.StorageModels;
 using AutoTest.Integration.Test.Fixtures;
@@ -22,7 +23,7 @@ public class TestRunsControllerShould : IClassFixture<CustomWebApplicationFactor
     [Fact]
     public async Task GetResults()
     {
-        var res = await unAuthorisedClient.GetAsync("api/events/22/tests/2/testRuns");
+        var res = await unAuthorisedClient.GetAsync("api/events/22/tests/2/testRuns", CancellationToken.None);
         res.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
         var content = await res.DeserialiseAsync<IEnumerable<TestRun>>();
         content.Should().NotBeEmpty();

--- a/Test/AutoTest.Integration.Test/Fixtures/TestAuthHandler.cs
+++ b/Test/AutoTest.Integration.Test/Fixtures/TestAuthHandler.cs
@@ -10,8 +10,8 @@ namespace AutoTest.Integration.Test.Fixtures;
 public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
     public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
-        ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        ILoggerFactory logger, UrlEncoder encoder)
+        : base(options, logger, encoder)
     {
     }
 

--- a/Test/AutoTest.Unit.Test/AutoTest.Unit.Test.csproj
+++ b/Test/AutoTest.Unit.Test/AutoTest.Unit.Test.csproj
@@ -17,9 +17,6 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Test/AutoTest.Unit.Test/AutoTest.Unit.Test.csproj
+++ b/Test/AutoTest.Unit.Test/AutoTest.Unit.Test.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,12 +13,10 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions.ArgumentMatchers.Moq" Version="3.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="MockQueryable.Moq" Version="10.0.8" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.AutoMock" Version="4.0.2" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Test/AutoTest.Unit.Test/DbSetExtensionsShould.cs
+++ b/Test/AutoTest.Unit.Test/DbSetExtensionsShould.cs
@@ -14,10 +14,11 @@ public class DbSetExtensionsShould
     [Fact]
     public async Task Insert()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var db = InMemDbFixture.GetDbContext();
-        var method = await db.Marshals.Upsert(new Domain.StorageModels.Marshal(1, "", "", "", 2, 3, ""), a => a.MarshalId == 1, CancellationToken.None);
+        var method = await db.Marshals.Upsert(new Domain.StorageModels.Marshal(1, "", "", "", 2, 3, ""), a => a.MarshalId == 1, cancellationToken);
 
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(cancellationToken);
 
         db.Marshals.Count().Should().Be(1);
         method.Should().Be(UpdateStatus.Add);
@@ -26,14 +27,14 @@ public class DbSetExtensionsShould
     [Fact]
     public async Task Update()
     {
-
+        var cancellationToken = TestContext.Current.CancellationToken;
         var db = InMemDbFixture.GetDbContext();
         db.Marshals.Add(new Domain.StorageModels.Marshal(1, "", "", "", 2, 3, ""));
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(cancellationToken);
         db.ChangeTracker.Clear();
-        var method = await db.Marshals.Upsert(new Domain.StorageModels.Marshal(1, "", "", "", 2, 3, ""), a => a.MarshalId == 1ul, CancellationToken.None);
+        var method = await db.Marshals.Upsert(new Domain.StorageModels.Marshal(1, "", "", "", 2, 3, ""), a => a.MarshalId == 1ul, cancellationToken);
 
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(cancellationToken);
 
         db.Marshals.Count().Should().Be(1);
         method.Should().Be(UpdateStatus.Update);

--- a/Test/AutoTest.Unit.Test/Handlers/GetEditableEntrantsHandlerShould.cs
+++ b/Test/AutoTest.Unit.Test/Handlers/GetEditableEntrantsHandlerShould.cs
@@ -28,17 +28,18 @@ public class GetEditableEntrantsHandlerShould
     }
 
     [Fact]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD103:Call async methods when in an async method", Justification = "<Pending>")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD103:Call async methods when in an async method", Justification = "In-memory database")]
     public async Task GetEntrants()
     {
+        var cancellationToken = TestContext.Current.CancellationToken;
         var marshals = new[] {
             new Entrant(1, 22, "Joe", "Bloggs", "test@test.com", "A", 99, Domain.Enums.Age.Senior, false, null),
             new Entrant(2, 22, "Joe", "Bloggs", "a@a.com", "A", 99, Domain.Enums.Age.Senior, false, null)
         };
         db.Entrants.AddRange(marshals);
-        await db.SaveChangesAsync();
+        await db.SaveChangesAsync(cancellationToken);
 
-        var res = await sut.Handle(new("test@test.com"), CancellationToken.None);
+        var res = await sut.Handle(new("test@test.com"), cancellationToken);
 
         res.Should().BeEquivalentTo(new[] { marshals.First().EntrantId });
         mr.VerifyAll();


### PR DESCRIPTION
- Migrate test projects to xUnit v3 and remove old test SDK references
- Add OutputType Exe to test project files
- Pass CancellationToken.None or test context token to all async test methods
- Update TestAuthHandler constructor to match new base signature
- Improve code formatting and update suppression justifications