### PR TITLE
Improve CI/CD: concurrency, caching, and build steps

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,6 @@ on:
     paths-ignore:
       - "**/*.md"
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ master ]
     paths-ignore:
       - "**/*.md"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,9 +33,6 @@ jobs:
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.x'
-
-      - name: Build with dotnet
-        run: dotnet build --configuration Release
 
       - name: dotnet publish
         run: dotnet publish -c Release -o "${{env.DOTNET_ROOT}}/myapp"

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -27,6 +27,12 @@ jobs:
       uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: ${{ runner.os }}-nuget-
     - name: Install dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
- Added concurrency group to deploy.yml to avoid overlapping deployments for the same ref (cancel-in-progress: false).
- Removed explicit dotnet build step from deploy.yml; now using only dotnet publish.
- Added NuGet package cache to dotnet-ci.yml with actions/cache for faster restores.